### PR TITLE
FLOE-420: Uses nodemon to manage app in a dev env

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,11 @@ nodejs_app_git_branch: ''
 # Example: server.js
 nodejs_app_start_script: ''
 
+# Enabling this will manage the application using https://github.com/remy/nodemon
+# so that Node process is restarted when file system changes are detected. This
+# will only work if 'nodejs_app_start_script' is set.
+nodejs_app_dev_env: false
+
 # A TCP port used by the application.
 # Example: 8080
 nodejs_app_tcp_port: ''
@@ -70,10 +75,12 @@ nodejs_app_host_address: 127.0.0.1
 # MANDATORY
 # The group name used by the application process.
 nodejs_app_groupname: nodejs
+nodejs_app_dev_groupname: vagrant
 
 # MANDATORY
 # The user account name used by the application process.
 nodejs_app_username: nodejs
+nodejs_app_dev_username: vagrant
 
 # A YAML list of RPM packages that the application requires.
 # Example:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,3 +33,10 @@
     state: present
   with_items: "{{ nodejs_app_rpm_packages }}"
   when: (is_centos) and (nodejs_app_rpm_packages)
+
+- name: Install nodemon if a development environment is being used
+  npm:
+    name: nodemon
+    state: present
+    global: yes
+  when: nodejs_app_dev_env

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,3 +40,4 @@
     state: present
     global: yes
   when: nodejs_app_dev_env
+  

--- a/templates/systemd_unit.j2
+++ b/templates/systemd_unit.j2
@@ -2,10 +2,16 @@
 Description={{ nodejs_app_name }}
 
 [Service]
-WorkingDirectory={{ nodejs_app_install_dir }} 
+WorkingDirectory={{ nodejs_app_install_dir }}
+{% if nodejs_app_dev_env %}
+ExecStart={{ nodejs_dev_executable }} {{ nodejs_app_start_script }}
+User={{ nodejs_app_dev_username }}
+Group={{ nodejs_app_dev_groupname }}
+{% else %}
 ExecStart={{ nodejs_executable }} {{ nodejs_app_start_script }}
 User={{ nodejs_app_username }}
 Group={{ nodejs_app_groupname }}
+{% endif %}
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,8 @@
 ---
 nodejs_executable: /usr/bin/node
 
+nodejs_dev_executable: /usr/bin/nodemon
+
 nodejs_rpm_packages:
   - "{{ nodejs_package_name | mandatory }}-{{ nodejs_version | mandatory }}"
   - npm


### PR DESCRIPTION
These changes add a "nodejs_app_dev_env" option which when set to 'true' will use https://github.com/remy/nodemon to start the app. Nodemon will watch for file system changes and restart the app when required. 