### PR TITLE
Use NodeSource packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Node.js Ansible Role
 
-This role assists with deploying a Node.js application on Fedora 22, CentOS 7, or a Docker container. It currently performs the following tasks:
+This role assists with deploying a Node.js application on Fedora 22, CentOS 7, or a Docker container (based on CentOS/Fedora). 
 
-* Installs Node.js, NPM, and any other requested packages
+It currently performs the following tasks:
+
+* Installs Node.js (from a limited set of supported versions), npm, git, grunt-cli and any other additional npm/RPM package required by the application.
 * Creates a user account and group used by the application
 * Clones the application's Git repository
 * Runs ``npm install`` in the Git working directory or specific commands requested by the user
@@ -32,14 +34,13 @@ Here is an example playbook that uses this role:
 
 ```
 - hosts: localhost
-  user: root
+  become: yes
+  become_user: root
 
   vars:
     nodejs_app_name: preferences-server
     nodejs_app_git_repo: https://github.com/gpii/universal.git
     nodejs_app_git_branch: master
-    nodejs_app_rpm_packages:
-      - nodejs-grunt-cli
     nodejs_app_commands:
       - npm install
       - grunt dedupe-infusion

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@
 # Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.1.1)
 nodejs_version: 0.10.36
 
+# If a specific npm version is needed, specify it here
+#nodejs_npm_version: 2.14.5
+
 # List of additional RPM packages required by application
 nodejs_app_rpm_packages: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,15 +3,14 @@
 # set. Variables with values provided can be used as-is unless there is a reason
 # to override them.
 
-# The nodejs_package_name and nodejs_version variables are used together to
-# determine which package gets installed. Both should reflect the packages
-# available in the Fedora and EPEL repositories.
-
-# MANDATORY
-nodejs_package_name: nodejs
-
-# MANDATORY
+# Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.1.1)
 nodejs_version: 0.10.36
+
+# List of additional RPM packages required by application
+nodejs_app_rpm_packages: []
+
+# List of additional NPM packages required by application
+nodejs_app_npm_packages: []
 
 # MANDATORY
 # A hyphenated string representing the application's name. It is used to name
@@ -82,21 +81,15 @@ nodejs_app_dev_groupname: vagrant
 nodejs_app_username: nodejs
 nodejs_app_dev_username: vagrant
 
-# A YAML list of RPM packages that the application requires.
-# Example:
-# - git
-# - nodejs-grunt-cli
-nodejs_app_rpm_packages: []
-
 # MANDATORY
 # The absolute file system path where the Git working directory will be located.
 nodejs_app_install_dir: "/opt/{{ nodejs_app_name }}"
 
-# A YAML list of commands that will be executed in order within the application's
+# List of commands that will be executed in order within the application's
 # Git working directory.
 nodejs_app_commands: []
 
-# A YAML list of environment variables required by the application.
+# List of environment variables required by the application.
 # Example:
 # - NODE_ENV=development.all.local
 nodejs_app_env_vars: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,6 +37,13 @@
     - "{{ nodejs_app_rpm_packages }}"
   when: is_centos
 
+- name: Adjust npm version
+  npm:
+    name: npm
+    version: "{{ nodejs_npm_version }}"
+    global: yes
+  when: nodejs_npm_version
+
 - name: Install required npm packages
   npm:
     name: "{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
     name: npm
     version: "{{ nodejs_npm_version }}"
     global: yes
-  when: nodejs_npm_version
+  when: nodejs_npm_version is defined
 
 - name: Install required npm packages
   npm:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,5 @@
 ---
+
 # Workaround for https://github.com/ansible/ansible-modules-extras/issues/471
 - name: Install Yum Utilities
   shell: dnf -y install yum-utils
@@ -6,33 +7,43 @@
     creates: /usr/bin/repoquery
   when: is_fedora
 
-- name: Install Node.js related RPM packages on Fedora
+- name: Install Node.js on Fedora
   dnf:
-    name: "{{ item }}"
+    name: "{{ nodejs_fedora_rpms[nodejs_version] }}"
     state: present
-  with_items: "{{ nodejs_rpm_packages }}"
   when: is_fedora
 
-- name: Install application related RPM packages on Fedora
+- name: Install additional RPM packages on Fedora
   dnf:
     name: "{{ item }}"
-    state: present
-  with_items: "{{ nodejs_app_rpm_packages }}"
-  when: (is_fedora) and (nodejs_app_rpm_packages)
-  
-- name: Install Node.js related RPM packages on CentOS
+    state: latest
+  with_flattened:
+    - "{{ nodejs_rpm_packages }}"
+    - "{{ nodejs_app_rpm_packages }}"
+  when: is_fedora
+
+- name: Install Node.js on CentOS
   yum:
-    name: "{{ item }}"
+    name: "{{ nodejs_centos_rpms[nodejs_version] }}"
     state: present
-  with_items: "{{ nodejs_rpm_packages }}"
   when: is_centos
 
-- name: Install application related RPM packages on CentOS
+- name: Install additional RPM packages on CentOS
   yum:
     name: "{{ item }}"
-    state: present
-  with_items: "{{ nodejs_app_rpm_packages }}"
-  when: (is_centos) and (nodejs_app_rpm_packages)
+    state: latest
+  with_flattened:
+    - "{{ nodejs_rpm_packages }}"
+    - "{{ nodejs_app_rpm_packages }}"
+  when: is_centos
+
+- name: Install required npm packages
+  npm:
+    name: "{{ item }}"
+    global: yes
+  with_items:
+    - "{{ nodejs_npm_packages }}"
+    - "{{ nodejs_app_npm_packages }}"
 
 - name: Install nodemon if a development environment is being used
   npm:
@@ -40,4 +51,3 @@
     state: present
     global: yes
   when: nodejs_app_dev_env
-  

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,11 +3,22 @@ nodejs_executable: /usr/bin/node
 
 nodejs_dev_executable: /usr/bin/nodemon
 
-nodejs_rpm_packages:
-  - "{{ nodejs_package_name | mandatory }}-{{ nodejs_version | mandatory }}"
-  - npm
-  - git
-
 nodejs_app_user_shell: /sbin/nologin
 
 nodejs_app_home_dir: /var/empty/nodejs
+
+nodejs_centos_rpms:
+  0.10.36:  https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.36-1nodesource.el7.centos.x86_64.rpm
+  0.10.40: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.40-1nodesource.el7.centos.x86_64.rpm
+  4.1.1: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.1.1-1nodesource.el7.centos.x86_64.rpm
+
+nodejs_fedora_rpms:
+  0.10.36: https://rpm.nodesource.com/pub/fc/21/x86_64/nodejs-0.10.36-1nodesource.fc21.x86_64.rpm
+  0.10.40: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.40-1nodesource.fc22.x86_64.rpm
+  4.1.1: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.1.1-1nodesource.fc22.x86_64.rpm
+
+nodejs_rpm_packages:
+  - git
+
+nodejs_npm_packages:
+  - grunt-cli

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,12 +10,12 @@ nodejs_app_home_dir: /var/empty/nodejs
 nodejs_centos_rpms:
   0.10.36:  https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.36-1nodesource.el7.centos.x86_64.rpm
   0.10.40: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.40-1nodesource.el7.centos.x86_64.rpm
-  4.1.1: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.1.1-1nodesource.el7.centos.x86_64.rpm
+  4.1.2: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.1.2-1nodesource.el7.centos.x86_64.rpm
 
 nodejs_fedora_rpms:
   0.10.36: https://rpm.nodesource.com/pub/fc/21/x86_64/nodejs-0.10.36-1nodesource.fc21.x86_64.rpm
   0.10.40: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.40-1nodesource.fc22.x86_64.rpm
-  4.1.1: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.1.1-1nodesource.fc22.x86_64.rpm
+  4.1.2: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.1.2-1nodesource.fc22.x86_64.rpm
 
 nodejs_rpm_packages:
   - git


### PR DESCRIPTION
Adds a set of supported Node.js versions (0.10.36, 10.0.40 and 4.1.1) coming from NodeSource EL7/Fedora repository. This gives up freedom from outdated EPEL packages.

Additional changes include the possibility of specifying a different npm version from that which comes bundled by NodeSource and also creates a separation between roles' and apps' required npm/rpm packages. The idea is to use RPM packages as much as possible for system-wide/non-nodejs packages and rely on npm exclusive for Node.js packages (stop using EPEL-provided npm packages).