### PR TITLE
Changes required for VirtualBox Shared Folders

### DIFF
--- a/files/npmrc
+++ b/files/npmrc
@@ -1,0 +1,2 @@
+bin-links = false
+

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -26,7 +26,7 @@
     chdir: "{{ nodejs_app_install_dir }}"
   with_items: "{{ nodejs_app_commands }}"
   become: yes
-  become_user: "{{ nodejs_app_dev_username if nodejs_app_dev_env else nodejs_app_username }}"
+  become_user: "{{ nodejs_app_dev_username if is_vagrant else nodejs_app_username }}"
   when: nodejs_app_commands
 
 - name: Set up VirtualBox Shared Folders npm workaround
@@ -34,7 +34,7 @@
     src: npmrc
     dest: "/home/{{ nodejs_app_dev_username if nodejs_app_dev_env else nodejs_app_username }}/.npmrc"
     mode: 0644
-    owner: "{{ nodejs_app_dev_username if nodejs_app_dev_env else nodejs_app_username }}"
-    group: "{{ nodejs_app_dev_groupname if nodejs_app_dev_env else nodejs_app_groupname }}"
+    owner: "{{ nodejs_app_dev_username if is_vagrant else nodejs_app_username }}"
+    group: "{{ nodejs_app_dev_groupname if is_vagrant else nodejs_app_groupname }}"
   when: nodejs_app_dev_env
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,5 +25,16 @@
   args:
     chdir: "{{ nodejs_app_install_dir }}"
   with_items: "{{ nodejs_app_commands }}"
+  become: yes
+  become_user: "{{ nodejs_app_dev_username if nodejs_app_dev_env else nodejs_app_username }}"
   when: nodejs_app_commands
+
+- name: Set up VirtualBox Shared Folders npm workaround
+  copy:
+    src: npmrc
+    dest: "/home/{{ nodejs_app_dev_username if nodejs_app_dev_env else nodejs_app_username }}/.npmrc"
+    mode: 0644
+    owner: "{{ nodejs_app_dev_username if nodejs_app_dev_env else nodejs_app_username }}"
+    group: "{{ nodejs_app_dev_groupname if nodejs_app_dev_env else nodejs_app_groupname }}"
+  when: nodejs_app_dev_env
 

--- a/templates/systemd_unit.j2
+++ b/templates/systemd_unit.j2
@@ -5,10 +5,13 @@ Description={{ nodejs_app_name }}
 WorkingDirectory={{ nodejs_app_install_dir }}
 {% if nodejs_app_dev_env %}
 ExecStart={{ nodejs_dev_executable }} {% if nodejs_app_monitor_file_extensions %} -e {{ nodejs_app_monitor_file_extensions|join(',') }} {% endif %} {{ nodejs_app_start_script }}
+{% else %}
+ExecStart={{ nodejs_executable }} {{ nodejs_app_start_script }}
+{% endif %}
+{% if nodejs_app_dev_env or is_vagrant %}
 User={{ nodejs_app_dev_username }}
 Group={{ nodejs_app_dev_groupname }}
 {% else %}
-ExecStart={{ nodejs_executable }} {{ nodejs_app_start_script }}
 User={{ nodejs_app_username }}
 Group={{ nodejs_app_groupname }}
 {% endif %}


### PR DESCRIPTION
These changes cause application commands to be run either as ``vagrant`` (if a Vagrant environment is detected by the ``facts`` role) or the ``nodejs`` user. A [VirtualBox Shared Folders/npm symlink workaround](https://www.virtualbox.org/ticket/10085) is also included. 