### PR TITLE
Bump Node.js 4.x to 4.2.0 (first LTS version) and reject nodejs- RPM packages

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,7 @@
 - name: Fail if nodejs- RPM packages are specified in nodejs_app_rpm_packages
   fail:
     msg: "Node.js packages should be installed through npm (see nodejs_app_npm_packages)"
-  when: "'nodejs-' in {{ nodejs_app_rpm_packages|join(' ') }}"
+  when: "'nodejs-' in '{{ nodejs_app_rpm_packages|join(' ') }}'"
 
 - name: Install additional RPM packages on CentOS
   yum:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,6 +28,11 @@
     state: present
   when: is_centos
 
+- name: Fail if nodejs- RPM packages are specified in nodejs_app_rpm_packages
+  fail:
+    msg: "Node.js packages should be installed through npm (see nodejs_app_npm_packages)"
+  when: "'nodejs-' in {{ nodejs_app_rpm_packages|join(' ') }}"
+
 - name: Install additional RPM packages on CentOS
   yum:
     name: "{{ item }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,12 +10,12 @@ nodejs_app_home_dir: /var/empty/nodejs
 nodejs_centos_rpms:
   0.10.36:  https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.36-1nodesource.el7.centos.x86_64.rpm
   0.10.40: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.40-1nodesource.el7.centos.x86_64.rpm
-  4.1.2: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.1.2-1nodesource.el7.centos.x86_64.rpm
+  4.2.0: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.0-1nodesource.el7.centos.x86_64.rpm
 
 nodejs_fedora_rpms:
   0.10.36: https://rpm.nodesource.com/pub/fc/21/x86_64/nodejs-0.10.36-1nodesource.fc21.x86_64.rpm
   0.10.40: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.40-1nodesource.fc22.x86_64.rpm
-  4.1.2: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.1.2-1nodesource.fc22.x86_64.rpm
+  4.1.2: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.0-1nodesource.fc22.x86_64.rpm
 
 nodejs_rpm_packages:
   - git


### PR DESCRIPTION
    [gtirloni@station1 first-discovery-server]$ vagrant ssh
    Last login: Tue Oct 13 13:17:25 2015 from 10.0.2.2
    ----------------------------------------------------------------
      CentOS 7.1.1503                             built 2015-10-09
    ----------------------------------------------------------------
    
    [vagrant@first-discovery-server ~]$ node --version
    v4.2.0
    
    [vagrant@first-discovery-server ~]$ curl http://localhost:8080
    Cannot GET /

Result of adding "nodejs-grunt-cli" to nodejs_app_rpm_packages:

    ==> default: TASK: [nodejs | Fail if nodejs- RPM packages are specified in nodejs_app_rpm_packages] *** 
    ==> default: failed: [localhost] => {"failed": true}
    ==> default: msg: Node.js packages should be installed through npm (see nodejs_app_npm_packages)

