### PR TITLE
Ensure systemd is restarted when unit files are created or changed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,3 @@
 - name: reload systemd
   command: systemctl daemon-reload
   when: not is_docker
-- name: Enable and/or restart systemd unit
-  service:
-    name: "{{ nodejs_app_name }}"
-    enabled: yes
-    state: restarted
-  when: (not is_docker) and (nodejs_app_start_script)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: not is_docker
+- name: Enable and/or restart systemd unit
+  service:
+    name: "{{ nodejs_app_name }}"
+    enabled: yes
+    state: restarted
+  when: (not is_docker) and (nodejs_app_start_script)

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -4,13 +4,9 @@
     src: systemd_unit.j2
     dest: "/etc/systemd/system/{{ nodejs_app_name }}.service"
   when: (not is_docker) and (nodejs_app_start_script)
-
-- name: Enable and/or restart systemd unit
-  service:
-    name: "{{ nodejs_app_name }}"
-    enabled: yes
-    state: restarted
-  when: (not is_docker) and (nodejs_app_start_script)
+  notify:
+    - reload systemd
+    - Enable and/or restart systemd unit
 
 - name: Create Supervisor config for Docker containers
   template:

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -6,7 +6,13 @@
   when: (not is_docker) and (nodejs_app_start_script)
   notify:
     - reload systemd
-    - Enable and/or restart systemd unit
+
+- name: Enable and/or restart systemd unit
+  service:
+    name: "{{ nodejs_app_name }}"
+    enabled: yes
+    state: restarted
+  when: (not is_docker) and (nodejs_app_start_script)    
 
 - name: Create Supervisor config for Docker containers
   template:


### PR DESCRIPTION
@gtirloni - could you review this PR since @avtar is away. It addresses an issue @jobara had yesterday when trying to update the port his First Discovery Server project was running on with a previously created VM (without doing a `vagrant destroy` to start).

The basic issue is that Ansible doesn't automatically reload systemd when existing unit configurations are changed (as opposed to restarted). Further info:
- http://lookonmyworks.co.uk/2015/06/24/ansible-systemctl-daemon-reload/
- https://github.com/ansible/ansible-modules-core/issues/191

This PR adds a handler that reloads systemd when notified. It also makes the enabling or restarting of the systemd unit for the nodejs app into a handler, as it should probably be one rather than a straight task.

I tested using a locally-modified version of https://github.com/avtar/first-discovery-server.git