### PR TITLE
Installs C++ compiler by default

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -19,6 +19,7 @@ nodejs_fedora_rpms:
 
 nodejs_rpm_packages:
   - git
+  - gcc-c++
 
 nodejs_npm_packages:
   - grunt-cli


### PR DESCRIPTION
This change adds a C++ compiler by default in hopes of avoiding issues such as this one:
https://botbot.me/freenode/fluid-work/2015-11-02/?msg=53310505&page=2