### PR TITLE
Adds Ansible dnf workaround

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,7 +16,7 @@
 - name: Install additional RPM packages on Fedora
   dnf:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_flattened:
     - "{{ nodejs_rpm_packages }}"
     - "{{ nodejs_app_rpm_packages }}"
@@ -42,7 +42,7 @@
 - name: Install additional RPM packages on CentOS
   yum:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_flattened:
     - "{{ nodejs_rpm_packages }}"
     - "{{ nodejs_app_rpm_packages }}"


### PR DESCRIPTION
dnf's ``state`` parameter cannot be set to ``latest`` [at the moment](https://github.com/ansible/ansible-modules-extras/issues/1239). Using ``present`` seems like a safe bet.