### PR TITLE
Add versions 0.10.41 and 4.2.3 and changes default to 0.10.41 (from 0.10.36)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,8 @@
 # set. Variables with values provided can be used as-is unless there is a reason
 # to override them.
 
-# Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.2.0, 4.2.1)
-nodejs_version: 0.10.36
+# Node.js version required by application (see vars/RedHat.yml for supported versions)
+nodejs_version: 0.10.41
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,18 +10,22 @@ nodejs_app_home_dir: /var/empty/nodejs
 nodejs_centos_rpms:
   0.10.36:  https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.36-1nodesource.el7.centos.x86_64.rpm
   0.10.40: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.40-1nodesource.el7.centos.x86_64.rpm
+  0.10.41: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.41-1nodesource.el7.centos.x86_64.rpm
   0.12.7: https://rpm.nodesource.com/pub_0.12/el/7/x86_64/nodejs-0.12.7-1nodesource.el7.centos.x86_64.rpm
   4.2.0: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.0-1nodesource.el7.centos.x86_64.rpm
   4.2.1: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.1-1nodesource.el7.centos.x86_64.rpm
   4.2.2: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.2-1nodesource.el7.centos.x86_64.rpm
+  4.2.3: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.3-1nodesource.el7.centos.x86_64.rpm
 
 nodejs_fedora_rpms:
   0.10.36: https://rpm.nodesource.com/pub/fc/21/x86_64/nodejs-0.10.36-1nodesource.fc21.x86_64.rpm
   0.10.40: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.40-1nodesource.fc22.x86_64.rpm
+  0.10.41: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.41-1nodesource.fc22.x86_64.rpm
   0.12.7: https://rpm.nodesource.com/pub_0.12/fc/22/x86_64/nodejs-0.12.7-1nodesource.fc22.x86_64.rpm
   4.2.0: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.0-1nodesource.fc22.x86_64.rpm
   4.2.1: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.1-1nodesource.fc22.x86_64.rpm
   4.2.2: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.2-1nodesource.fc22.x86_64.rpm
+  4.2.3: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.3-1nodesource.fc22.x86_64.rpm
 
 nodejs_rpm_packages:
   - git


### PR DESCRIPTION
GPII/universal test results:

    21:07:01.719:  jq: ***************
    21:07:01.719:  jq: All tests concluded: 776/776 total passed in 77675ms - PASS
    21:07:01.719:  jq: ***************

fluid-project/infusion built successfully too.

I'm changing the default to 0.10.41 because 0.10.36 is a security risk first and foremost but also because most developers have been working with the latest 0.10.x that they get from nodejs.org.