### PR TITLE
Add nodejs_options variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@
 # Node.js version required by application (see vars/RedHat.yml for supported versions)
 nodejs_version: 0.10.41
 
+# Additional options passed to the node executable (see node(1) man page)
+nodejs_options: ''
+
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5
 

--- a/templates/supervisor_nodejs.ini.j2
+++ b/templates/supervisor_nodejs.ini.j2
@@ -3,7 +3,7 @@
 {% if nodejs_app_dev_env %}
 command={{ nodejs_dev_executable }} {{ nodejs_app_start_script }}
 {% else %}
-command={{ nodejs_executable }} {{ nodejs_app_start_script }}
+command={{ nodejs_executable }} {{ nodejs_options }} {{ nodejs_app_start_script }}
 {% endif %}
 
 {% if nodejs_app_env_vars %}

--- a/templates/systemd_unit.j2
+++ b/templates/systemd_unit.j2
@@ -6,7 +6,7 @@ WorkingDirectory={{ nodejs_app_install_dir }}
 {% if nodejs_app_dev_env %}
 ExecStart={{ nodejs_dev_executable }} -L {% if nodejs_app_monitor_file_extensions %} -e {{ nodejs_app_monitor_file_extensions|join(',') }} {% endif %} {{ nodejs_app_start_script }}
 {% else %}
-ExecStart={{ nodejs_executable }} {{ nodejs_app_start_script }}
+ExecStart={{ nodejs_executable }} {{ nodejs_options }} {{ nodejs_app_start_script }}
 {% endif %}
 {% if nodejs_app_dev_env or is_vagrant %}
 User={{ nodejs_app_dev_username }}


### PR DESCRIPTION
I worry we may run into issues in production that would warrant tweaking node. Things like the GC but also an app that is making use of some ES6 not enabled by default.

This option is only used in non-dev environments, which is a deficiency. Supporting it in dev environment (i.e. nodemon) would require working with nodemon config files, which we don't use at this time. (but I can work on it if people thing it's worth while).

I wanted to support this to gather more opinions. The implementation is trivial.
