### PR TITLE
Proposal: Simplify Node.js version management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,13 @@
 # set. Variables with values provided can be used as-is unless there is a reason
 # to override them.
 
-# Node.js version required by application (see vars/RedHat.yml for supported versions)
-nodejs_version: 4.4.3
+# Node.js branch ('lts' for long-term support or 'current' for the current
+# branch)
+nodejs_branch: lts
+
+# Node.js version required by application (leave undefined for always using
+# the latest within the specified branch)
+#nodejs_version: x.y.z
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,11 +7,29 @@
     creates: /usr/bin/repoquery
   when: is_fedora
 
-- name: Install Node.js on Fedora
+- name: Enable Node.js LTS repository on Fedora
   dnf:
-    name: "{{ nodejs_fedora_rpms[nodejs_version] }}"
+    name: "{{ nodejs_lts_fedora_repository_rpm }}"
     state: present
-  when: is_fedora
+  when: is_fedora and nodejs_branch == "lts"
+
+- name: Enable Node.js Current repository on Fedora
+  dnf:
+    name: "{{ nodejs_current_fedora_repository_rpm }}"
+    state: present
+  when: is_fedora and nodejs_branch == "current"
+
+- name: Install latest Node.js version on Fedora
+  dnf:
+    name: nodejs
+    state: latest
+  when: is_fedora and nodejs_version is undefined
+
+- name: Install specific Node.js version on Fedora
+  dnf:
+    name: "nodejs-{{ nodejs_version }}"
+    state: present
+  when: is_fedora and nodejs_version is defined
 
 - name: Install additional RPM packages on Fedora
   dnf:
@@ -28,11 +46,29 @@
     state: present
   when: (is_vagrant) and (is_fedora)
 
-- name: Install Node.js on CentOS
-  yum:
-    name: "{{ nodejs_centos_rpms[nodejs_version] }}"
+- name: Enable Node.js LTS repository on CentOS
+  dnf:
+    name: "{{ nodejs_lts_centos_repository_rpm }}"
     state: present
-  when: is_centos
+  when: is_centos and nodejs_branch == "lts"
+
+- name: Enable Node.js Current repository on CentOS
+  dnf:
+    name: "{{ nodejs_current_centos_repository_rpm }}"
+    state: present
+  when: is_centos and nodejs_branch == "current"
+
+- name: Install latest Node.js version on CentOS
+  yum:
+    name: nodejs
+    state: latest
+  when: is_centos and nodejs_version is undefined
+
+- name: Install specific Node.js version on CentOS
+  dnf:
+    name: "nodejs-{{ nodejs_version }}"
+    state: present
+  when: is_centos and nodejs_version is defined
 
 - name: Fail if nodejs- RPM packages are specified in nodejs_app_rpm_packages
   fail:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,57 +7,13 @@ nodejs_app_user_shell: /sbin/nologin
 
 nodejs_app_home_dir: /var/empty/nodejs
 
-nodejs_centos_rpms:
-  0.10.36:  https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.36-1nodesource.el7.centos.x86_64.rpm
-  0.10.40: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.40-1nodesource.el7.centos.x86_64.rpm
-  0.10.41: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.41-1nodesource.el7.centos.x86_64.rpm
-  0.10.42: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.42-1nodesource.el7.centos.x86_64.rpm
-  0.10.43: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.43-1nodesource.el7.centos.x86_64.rpm
-  0.10.44: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.44-1nodesource.el7.centos.x86_64.rpm
-  0.10.45: https://rpm.nodesource.com/pub/el/7/x86_64/nodejs-0.10.45-1nodesource.el7.centos.x86_64.rpm
-  0.12.7: https://rpm.nodesource.com/pub_0.12/el/7/x86_64/nodejs-0.12.7-1nodesource.el7.centos.x86_64.rpm
-  4.2.0: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.0-1nodesource.el7.centos.x86_64.rpm
-  4.2.1: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.1-1nodesource.el7.centos.x86_64.rpm
-  4.2.2: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.2-1nodesource.el7.centos.x86_64.rpm
-  4.2.3: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.3-1nodesource.el7.centos.x86_64.rpm
-  4.2.4: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.4-1nodesource.el7.centos.x86_64.rpm
-  4.2.5: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.5-1nodesource.el7.centos.x86_64.rpm
-  4.2.6: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.2.6-1nodesource.el7.centos.x86_64.rpm
-  4.3.0: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.0-1nodesource.el7.centos.x86_64.rpm
-  4.3.1: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.1-1nodesource.el7.centos.x86_64.rpm
-  4.4.0: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.4.0-1nodesource.el7.centos.x86_64.rpm
-  4.4.1: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.4.1-1nodesource.el7.centos.x86_64.rpm
-  4.4.2: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.4.2-1nodesource.el7.centos.x86_64.rpm
-  4.4.3: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.4.3-1nodesource.el7.centos.x86_64.rpm
-  4.4.4: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.4.4-1nodesource.el7.centos.x86_64.rpm
-  6.0.0: https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodejs-6.0.0-1nodesource.el7.centos.x86_64.rpm
-  6.1.0: https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodejs-6.1.0-1nodesource.el7.centos.x86_64.rpm
+nodejs_lts_centos_repository_rpm: https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 
-nodejs_fedora_rpms:
-  0.10.36: https://rpm.nodesource.com/pub/fc/21/x86_64/nodejs-0.10.36-1nodesource.fc21.x86_64.rpm
-  0.10.40: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.40-1nodesource.fc22.x86_64.rpm
-  0.10.41: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.41-1nodesource.fc22.x86_64.rpm
-  0.10.42: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.42-1nodesource.fc22.x86_64.rpm
-  0.10.43: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.43-1nodesource.fc22.x86_64.rpm
-  0.10.44: https://rpm.nodesource.com/pub/fc/22/x86_64/nodejs-0.10.44-1nodesource.fc22.x86_64.rpm
-  0.10.45: https://rpm.nodesource.com/pub/fc/23/x86_64/nodejs-0.10.45-1nodesource.fc23.x86_64.rpm
-  0.12.7: https://rpm.nodesource.com/pub_0.12/fc/22/x86_64/nodejs-0.12.7-1nodesource.fc22.x86_64.rpm
-  4.2.0: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.0-1nodesource.fc22.x86_64.rpm
-  4.2.1: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.1-1nodesource.fc22.x86_64.rpm
-  4.2.2: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.2-1nodesource.fc22.x86_64.rpm
-  4.2.3: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.3-1nodesource.fc22.x86_64.rpm
-  4.2.4: https://rpm.nodesource.com/pub_4.x/fc/22/x86_64/nodejs-4.2.4-1nodesource.fc22.x86_64.rpm
-  4.2.5: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.2.5-1nodesource.fc23.x86_64.rpm
-  4.2.6: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.2.6-1nodesource.fc23.x86_64.rpm
-  4.3.0: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.3.0-1nodesource.fc23.x86_64.rpm
-  4.3.1: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.3.1-1nodesource.fc23.x86_64.rpm
-  4.4.0: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.4.0-1nodesource.fc23.x86_64.rpm
-  4.4.1: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.4.1-1nodesource.fc23.x86_64.rpm
-  4.4.2: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.4.2-1nodesource.fc23.x86_64.rpm
-  4.4.3: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.4.3-1nodesource.fc23.x86_64.rpm
-  4.4.4: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodejs-4.4.4-1nodesource.fc23.x86_64.rpm
-  6.0.0: https://rpm.nodesource.com/pub_6.x/fc/23/x86_64/nodejs-6.0.0-1nodesource.fc23.x86_64.rpm
-  6.1.0: https://rpm.nodesource.com/pub_6.x/fc/23/x86_64/nodejs-6.1.0-1nodesource.fc23.x86_64.rpm
+nodejs_lts_fedora_repository_rpm: https://rpm.nodesource.com/pub_4.x/fc/23/x86_64/nodesource-release-fc23-1.noarch.rpm
+
+nodejs_current_centos_repository_rpm: https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+
+nodejs_current_fedora_repository_rpm: https://rpm.nodesource.com/pub_6.x/fc/23/x86_64/nodesource-release-fc23-1.noarch.rpm
 
 nodejs_rpm_packages:
   - git


### PR DESCRIPTION
Since we started working on how to manage Node.js, the idea was to track each version, grind it through our stack and only offer the version that passed our tests and were supported. This was the vision, to the best of my memory. This was in the pre-LTS days / io.js days. There was a lot of uncertainty and we wanted some sanity is our environments.

Since these events have unfolded:

 * Node.js Foundation created
 * io.js merged back into node.js
 * 0.10.x targeted only for security updates
 * 4.x became the LTS branch (Long-Term Support)
 * 5.x became the current branch
 * Lastly, 6.x became the current branch and should become the next LTS release

On top of that, we adopted NodeSource's RPM packages instead of relying on OS-provided packages (which continues to offer outdated 0.10.x versions in CentOS/Fedora to this day). So it seems Node.js is much better maintained than when we started this work.

With that in mind, **I would like to propose we become less curators and start relying more on the work done by the Node.js Foundation and NodeSource**. My arguments in favor of this are:

* Tracking each version in lock-step has become burdensome for us and our developers, for little benefit. Node.js Foundation and NodeSource have released pretty stable versions since they committed to this new process and we haven't caught any errors affecting our apps (AFAIK).
* By moving slowly within each branch, bugs and deprecated features become hidden until we are forced to update due to a security issue, which in turns makes people afraid of updating. The whole 'Agile' thing, but backwards.
* With the goal of tracking LTS, new releases mean non-breaking changes and critical fixes. Security being a top priority, we cannot avoid updating most of the time.

Some final assumptions I'm making here:

 * For all practical purposes, 0.10.x is dead to the community and will be dead for us once GPII/universal can get rid of it. *I saw a graph showing 0.10 barely registered in npm's usage report but I can't find it. Trust me.*
 * We want to offer **one** LTS release and, for developers targeting new features, **one** Current release. There will be a moment where we decide to make the switch and track the newest LTS release.
 * There is an overlap of **1 year** between 6.x becoming LTS (Oct 2016) and 4.x getting into Maintenance mode (Oct 2017). 
 * In practice, we should expect that once 6.x LTS is released, 4.x will not receive a lot of attention except for security fixes and critical bugs. Node's LTS releases aren't like Linux/FreeBSD stable releases where things continue to move forward and features are even get backported. I have tried to track the LTS release announcement closely and to my semi-trained eye, that's not the case with Node.js.

This PR contains ***non-breaking*** changes required to supports either LTS or Current branches. If the version is not specified (default), the latest within the branch gets installed.

Although this Ansible role continues to let users specify the exact version that should be used, I would prefer if we discouraged that (at least if things are going to be supported in any way, as this would just create extra work for us). A subsequent change I want to propose is to only offer Docker images for the latest LTS or Current versions and not offer specific versions, thus reducing the complexity even further up the stack.

I would love to hear your thoughts on this subject (including @GPII//core-architecture-committers or @fluid-project/committers)