### PR TITLE
Added the hability to make string substitution in some files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,3 +115,20 @@ nodejs_app_commands: []
 # Example:
 # - NODE_ENV=development.all.local
 nodejs_app_env_vars: []
+
+# List of text config files and the regexps needed to change the settings
+# Example:
+# - src: "/configs/gpii.preferencesServer.config.production.json"
+#   changes:
+#     - regexp: '/user/%userToken'
+#       replace: '/preferences/%userToken'
+#     - regexp: '/otherurl/%user'
+#       replace: '/otherpreferences/%user'
+# - src: "/gpii/configs/gpii.preferencesServer.config.production.json"
+#   changes:
+#     - regexp: '/user/%userToken'
+#       replace: '/preferences/%userToken'
+#     - regexp: '/otherurl/%user'
+#       replace: '/otherpreferences/%user'
+nodejs_app_config_files: []
+

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -22,3 +22,38 @@
     owner: root
     group: root
   when: (is_docker) and (nodejs_app_start_script)
+
+- block:
+
+    - name: Copy Flow Manager configuration file to temporary location in a Vagrant environment
+      command: cp '{{ item.src }}' '/tmp/{{ item.src | basename }}'
+      with_items:
+        - "{{ nodejs_app_config_files }}"
+
+    - name: Replace the production Preferences Server's address with a user provided one
+      replace:
+        dest: '/tmp/{{ item.0.src | basename }}'
+        regexp: '{{ item.1.regexp }}'
+        replace: '{{ item.1.replace }}'
+      notify: Restart the application systemd unit
+      with_subelements:
+        - "{{ nodejs_app_config_files }}"
+        - changes
+
+    - name: Move Flow Manager configuration file back to original location in a Vagrant environment
+      command: mv '/tmp/{{ item.src | basename }}' '{{ item.src }}'
+      with_items:
+        - "{{ nodejs_app_config_files }}"
+
+  when: is_vagrant
+
+# If VirtualBox Shared Folders on Windows aren't being used then modify files directly.
+- name: Replace the production Preferences Server's address with a user provided one
+  replace:
+    dest: '{{ item.0.src }}'
+    regexp: '{{ item.1.regexp }}'
+    replace: '{{ item.1.replace }}'
+  notify: Restart the application systemd unit
+  with_subelements:
+    - "{{ nodejs_app_config_files }}"
+    - changes

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -25,12 +25,12 @@
 
 - block:
 
-    - name: Copy Flow Manager configuration file to temporary location in a Vagrant environment
+    - name: Copy application configuration file to temporary location in a Vagrant environment
       command: cp '{{ item.src }}' '/tmp/{{ item.src | basename }}'
       with_items:
         - "{{ nodejs_app_config_files }}"
 
-    - name: Replace the production Preferences Server's address with a user provided one
+    - name: Replace the strings in the application configuration files
       replace:
         dest: '/tmp/{{ item.0.src | basename }}'
         regexp: '{{ item.1.regexp }}'
@@ -40,7 +40,7 @@
         - "{{ nodejs_app_config_files }}"
         - changes
 
-    - name: Move Flow Manager configuration file back to original location in a Vagrant environment
+    - name: Move application configuration file back to original location in a Vagrant environment
       command: mv '/tmp/{{ item.src | basename }}' '{{ item.src }}'
       with_items:
         - "{{ nodejs_app_config_files }}"
@@ -48,7 +48,7 @@
   when: is_vagrant
 
 # If VirtualBox Shared Folders on Windows aren't being used then modify files directly.
-- name: Replace the production Preferences Server's address with a user provided one
+- name: Replace the strings in the application configuration files
   replace:
     dest: '{{ item.0.src }}'
     regexp: '{{ item.1.regexp }}'


### PR DESCRIPTION
[ansible-flowmanager](https://github.com/gpii-ops/ansible-flow-manager) and [ansible-preferences-server](https://github.com/gpii-ops/ansible-preferences-server) are two roles that use this nodejs role to deploy both GPII's services. Those roles are only a set of variables and a couple of tasks that make some string substitutions in config files.

With the following approach, we can get rid of both roles and only use a set of variables and this nodejs role to deploy these two services and others.
