### PR TITLE
Some fixes that help the issue GPII-1876

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,7 +17,7 @@
     repo: "{{ nodejs_app_git_repo | mandatory }}"
     dest: "{{ nodejs_app_install_dir | mandatory }}"
     version: "{{ nodejs_app_git_branch | mandatory }}"
-    depth: 1
+    refspec: "+refs/pull/*/head:refs/remotes/origin/pr/*"
   when: nodejs_app_git_clone
 
 - name: Make sure the application install directory exists and is owned by the appropriate user

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,7 +27,6 @@
       group: "{{ nodejs_app_dev_username if is_vagrant else nodejs_app_username }}"
       recurse: true
       state: directory
-  when: not is_vagrant
 
 # Begin Windows/npm path workaround of copying application directory contents to a path
 # not managed by VirtualBox Shared Folders or exposed to Windows. Run commands like


### PR DESCRIPTION
These two changes are needed to run the [vagrant-vmenv samples](https://github.com/amatas/vagrant-vmenv/tree/master/samples). 

The first commit seems a bug because that task is never executed in vagrant environments, so the working directory couldn't be created or couldn't have the correct permissions in the case of being executed in a vagrant VM.

The second commit can be useful in order to fetch a particular PR to test. It allows to get a PR of the repository using the pattern "pr/[id]" to fetch a PR of the Github repository.
