### PR TITLE
Add nodejs_npm_symlinks tunable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,11 @@ nodejs_branch: lts
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5
 
+# If NPM should use symlinks or not. This is necessary to work around issues in
+# NPM when using VirtualBox shared folders on a Windows host. It might be disabled
+# on other platforms (Linux/OSX) if desired.
+nodejs_npm_symlinks: false
+
 # List of additional RPM packages required by application
 nodejs_app_rpm_packages: []
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,7 +47,7 @@
     mode: 0644
     owner: "{{ nodejs_app_dev_username }}"
     group: "{{ nodejs_app_dev_groupname }}"
-  when: (is_vagrant) and (nodejs_app_commands)
+  when: (is_vagrant) and (nodejs_app_commands) and not (nodejs_npm_symlinks)
 
 - name: Run application related commands as the application user
   command: "{{ item }}"


### PR DESCRIPTION
This is a proposed solution for environments that do not have issues with NPM symlinks (namely Linux and OSX hosts). 

It still defaults to not using symlinks though, making it a necessary change for Linux/OSX users (they need to pass nodejs_npm_symlinks=true somehow in their provisioning scripts).

We could make it default=true, however I can't see a majority of our users on any platform. They seem equally distributed between Windows, Linux and OSX hosts so I can't decide what's better in this case and so I chose to keep the same behavior the has been working with node4 and npm2 (symlinks=off).

