### PR TITLE
Npm3 stack issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,11 @@ nodejs_branch: lts
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5
 
+# If NPM should use symlinks or not. This is necessary to work around issues in
+# NPM when using VirtualBox shared folders on a Windows host. It might be disabled
+# on other platforms (Linux/OSX) if desired.
+nodejs_npm_symlinks: false
+
 # List of additional RPM packages required by application
 nodejs_app_rpm_packages: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,11 +14,6 @@ nodejs_branch: lts
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5
 
-# If NPM should use symlinks or not. This is necessary to work around issues in
-# NPM when using VirtualBox shared folders on a Windows host. It might be disabled
-# on other platforms (Linux/OSX) if desired.
-nodejs_npm_symlinks: false
-
 # List of additional RPM packages required by application
 nodejs_app_rpm_packages: []
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,7 +47,7 @@
     mode: 0644
     owner: "{{ nodejs_app_dev_username }}"
     group: "{{ nodejs_app_dev_groupname }}"
-  when: (is_vagrant) and (nodejs_app_commands)
+  when: (is_vagrant) and (nodejs_app_commands) and not (nodejs_npm_symlinks)
 
 - name: Run application related commands as the application user
   command: "{{ item }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -55,7 +55,7 @@
     mode: 0644
     owner: "{{ nodejs_app_dev_username }}"
     group: "{{ nodejs_app_dev_groupname }}"
-  when: (is_vagrant) and (nodejs_app_commands) and not (nodejs_npm_symlinks)
+  when: (is_vagrant) and (nodejs_app_commands)
 
 - name: Run application related commands as the application user
   command: "{{ item }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,6 +29,13 @@
       state: directory
   when: not is_vagrant
 
+# Workaround for NPM 3.x stack exceeded issue 
+- name: Increase V8 stack size to work around issue in npm 3.x
+  lineinfile:
+    line: '#!/usr/bin/node --stack-size=2048'
+    regexp: '^#!.*'
+    state: present
+
 # Begin Windows/npm path workaround of copying application directory contents to a path
 # not managed by VirtualBox Shared Folders or exposed to Windows. Run commands like
 # 'npm install' in the temporary directory and then copy the results back to the original

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -35,6 +35,7 @@
     line: '#!/usr/bin/node --stack-size=2048'
     regexp: '^#!.*'
     state: present
+    dest: /usr/bin/npm
 
 # Begin Windows/npm path workaround of copying application directory contents to a path
 # not managed by VirtualBox Shared Folders or exposed to Windows. Run commands like


### PR DESCRIPTION
Npm 3.x running without symlinks encounters a 'stack exceeded' error. 

The issue is not present when running npm 3.x with symlinks. However, turning symlinks on causes Windows hosts sharing a directory through VirtualBox shared folders to break. Thus, it's necessary to keep symlinks off.

The workaround is to increase node's stack size from the standard 900KB+ to 2048KB, thus avoiding the stack size exceeded issue when running `npm install` on GPII/universal. It's likely other repositories might face the same issue in the future. That's why the change is being proposed to /usr/bin/npm directly, so other projects "benefit" from the increased stack size.

In the future, when both npm 3.x and VirtualBox share folders get a little bit better, we could turn symlinks back on and not worry about stack sizes or npm getting stuck inside VM guests.