### PR TITLE
Remove split node_modules workaround (added to Vagrantfile)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,12 +64,6 @@ nodejs_app_start_script: ''
 # will only work if 'nodejs_app_start_script' is set.
 nodejs_app_dev_env: false
 
-# There are multiple issues in NPM 3.x and VirtualBox shared folders that
-# cause `npm install` to fail. To work around these issues, we bind mount
-# the node_modules directory outside the Virtual Shared Folders area so it 
-# uses the native filesystem.
-nodejs_app_shadow_node_modules: true
-
 # A YAML list of file extensions that will be monitored for changes. If changes are
 # detected then the Node.js process will be restarted.
 nodejs_app_monitor_file_extensions:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,38 +29,6 @@
       state: directory
   when: not is_vagrant
 
-# Workaround for various issues with VirtualBox shared folders and NPM is
-# to bind mount the node_modules directory outside the shared folder mount
-# point.
-
-- name: Create application's node_modules directory under /var/tmp
-  file:
-    path: '/var/tmp/{{ nodejs_app_dev_username }}-{{ nodejs_app_name }}'
-    owner: '{{ nodejs_app_dev_username }}'
-    group: '{{ nodejs_app_dev_username }}'
-    state: directory
-    mode: '0775'
-  when: (is_vagrant) and (nodejs_app_shadow_node_modules)
-
-- name: Ensure the application's node_module directory exists
-  file:
-    path: '{{ nodejs_app_install_dir }}/node_modules'
-    owner: '{{ nodejs_app_dev_username }}'
-    group: '{{ nodejs_app_dev_username }}'
-    state: directory
-    mode: '0775'
-  when: (is_vagrant) and (nodejs_app_shadow_node_modules)
-
-
-- name: Bind mount application's node_modules
-  mount:
-    name: '{{ nodejs_app_install_dir }}/node_modules'
-    src: '/var/tmp/{{ nodejs_app_dev_username }}-{{ nodejs_app_name }}'
-    fstype: none
-    opts: bind,defaults
-    state: mounted
-  when: (is_vagrant) and (nodejs_app_shadow_node_modules)
-
 - name: Run application related commands as the application user
   command: "{{ item }}"
   args:


### PR DESCRIPTION
The workaround I had proposed before was proved faulty by @cindyli. 

Because the VirtualBox shared folder is the last thing that gets created when a VM boots, the entry in /etc/fstab was firing too early (before the vboxsf mount point was ready).

I tried numerous alternatives to trigger the bind mount only after the vboxsf mount point was ready, but they were all unreliable or too complicated (systemd path monitor, udev rules, inotify, etc).

Finally, I noticed that a Vagrant provision task can be made to always run (even if the machine has already been provisioned), like this:

    config.vm.provision "shell", run: "always", inline: <<-SHELL
      sudo mkdir -p /var/tmp/#{app_name}/node_modules
      sudo mount -o bind /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
    SHELL

Since this workaround only applies to Vagrant/VirtualBox environments, I would like to propose we move this complexity into where it belongs (the Vagrantfile) and avoid complicating the node.js role further.

This PR removes the previous (faulty) workaround and adds nothing in its place. It's up to the repository maintainer to make sure the Vagrantfile has the aforementioned code. This code will run on `vagrant up` and nothing else is needed.

If this accepted, I can create another PR to fix the Vagrantfile of the other known git repositories that use this.

@avtar @amatas @cindyli @amb26 @simonbates @javihernandez and others, do you think this is doable?