### PR TITLE
Add ability to install Yarn package manager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ nodejs_branch: lts
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.14.5
 
+# Enable Yarn package manager
+nodejs_yarn_enabled: true
+
 # List of additional RPM packages required by application
 nodejs_app_rpm_packages: []
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -84,6 +84,18 @@
     - "{{ nodejs_app_rpm_packages }}"
   when: is_centos
 
+- name: Enable Yarn repository on CentOS/Fedora
+  get_url:
+    url: "{{ nodejs_yarn_repository_url }}"
+    dest: "/etc/yum.repos.d/yarn.repo"
+  when: nodejs_yarn_enabled
+
+- name: Install Yarn package manager on CentOS/Fedora
+  package:
+    name: yarn
+    state: latest
+  when: nodejs_yarn_enabled
+
 - name: Ensure rsync is installed for npm path workaround if a CentOS Vagrant environment is being used
   yum:
     name: rsync

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -15,6 +15,8 @@ nodejs_current_centos_repository_rpm: https://rpm.nodesource.com/pub_7.x/el/7/x8
 
 nodejs_current_fedora_repository_rpm: https://rpm.nodesource.com/pub_7.x/fc/24/x86_64/nodesource-release-fc24-1.noarch.rpm
 
+nodejs_yarn_repository_url: https://dl.yarnpkg.com/rpm/yarn.repo
+
 nodejs_rpm_packages:
   - git
   - gcc-c++


### PR DESCRIPTION
This should be harmless (everything else is still done through npm) but we allow us to slowly start using yarn whenever needed.

If the [yarn ansible module](https://github.com/ansible/ansible-modules-extras/pull/3199) gets accepted and everything works as expected, we could even switch the Ansible tasks from npm to yarn in the future.