### PR TITLE
GPII-2158 - Update to Fedora 26 packages

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,11 +9,11 @@ nodejs_app_home_dir: /var/empty/nodejs
 
 nodejs_lts_centos_repository_rpm: https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 
-nodejs_lts_fedora_repository_rpm: https://rpm.nodesource.com/pub_6.x/fc/24/x86_64/nodesource-release-fc24-1.noarch.rpm
+nodejs_lts_fedora_repository_rpm: https://rpm.nodesource.com/pub_6.x/fc/26/x86_64/nodesource-release-fc26-1.noarch.rpm
 
 nodejs_current_centos_repository_rpm: https://rpm.nodesource.com/pub_8.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 
-nodejs_current_fedora_repository_rpm: https://rpm.nodesource.com/pub_8.x/fc/24/x86_64/nodesource-release-fc24-1.noarch.rpm
+nodejs_current_fedora_repository_rpm: https://rpm.nodesource.com/pub_8.x/fc/26/x86_64/nodesource-release-fc26-1.noarch.rpm
 
 nodejs_yarn_repository_url: https://dl.yarnpkg.com/rpm/yarn.repo
 


### PR DESCRIPTION
Just updating the role to use F26 packages intead of F24 we were using previously.

Not changing Node.js version.