### PR TITLE
Update LTS to 10.x and Current to 11.x

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,13 +7,13 @@ nodejs_app_user_shell: /sbin/nologin
 
 nodejs_app_home_dir: /var/empty/nodejs
 
-nodejs_lts_centos_repository_rpm: https://rpm.nodesource.com/pub_8.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+nodejs_lts_centos_repository_rpm: https://rpm.nodesource.com/pub_10.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 
-nodejs_lts_fedora_repository_rpm: https://rpm.nodesource.com/pub_8.x/fc/28/x86_64/nodesource-release-fc28-1.noarch.rpm
+nodejs_lts_fedora_repository_rpm: https://rpm.nodesource.com/pub_10.x/fc/28/x86_64/nodesource-release-fc28-1.noarch.rpm
 
-nodejs_current_centos_repository_rpm: https://rpm.nodesource.com/pub_10.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
+nodejs_current_centos_repository_rpm: https://rpm.nodesource.com/pub_11.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 
-nodejs_current_fedora_repository_rpm: https://rpm.nodesource.com/pub_10.x/fc/28/x86_64/nodesource-release-fc28-1.noarch.rpm
+nodejs_current_fedora_repository_rpm: https://rpm.nodesource.com/pub_11.x/fc/28/x86_64/nodesource-release-fc28-1.noarch.rpm
 
 nodejs_yarn_repository_url: https://dl.yarnpkg.com/rpm/yarn.repo
 


### PR DESCRIPTION
New packages are available from NodeSource repository now.

Test results:

```
(venv) [gtirloni@localhost ansible-nodejs]$ molecule test
--> Destroying instances...
--> Downloading dependencies with 'galaxy'...
- extracting ansible-facts to /home/gtirloni/code/idrc/ansible-nodejs/.molecule/roles/ansible-facts
- ansible-facts was installed successfully
--> Checking playbook's syntax...

playbook: playbook.yml
--> Creating instances...
Bringing machine 'ansible-nodejs' up with 'virtualbox' provider...
==> ansible-nodejs: Box 'centos/7' could not be found. Attempting to find and install...
    ansible-nodejs: Box Provider: virtualbox
    ansible-nodejs: Box Version: >= 0
==> ansible-nodejs: Loading metadata for box 'centos/7'
    ansible-nodejs: URL: https://vagrantcloud.com/centos/7
==> ansible-nodejs: Adding box 'centos/7' (v1809.01) for provider: virtualbox
    ansible-nodejs: Downloading: https://vagrantcloud.com/centos/boxes/7/versions/1809.01/providers/virtualbox.box
    ansible-nodejs: Download redirected to host: cloud.centos.org
==> ansible-nodejs: Successfully added box 'centos/7' (v1809.01) for 'virtualbox'!
==> ansible-nodejs: Importing base box 'centos/7'...
==> ansible-nodejs: Matching MAC address for NAT networking...
==> ansible-nodejs: Checking if box 'centos/7' is up to date...
==> ansible-nodejs: Setting the name of the VM: ansible-nodejs_ansible-nodejs_1540905522519_21635
==> ansible-nodejs: Clearing any previously set network interfaces...
==> ansible-nodejs: Preparing network interfaces based on configuration...
    ansible-nodejs: Adapter 1: nat
==> ansible-nodejs: Forwarding ports...
    ansible-nodejs: 22 (guest) => 2222 (host) (adapter 1)
==> ansible-nodejs: Running 'pre-boot' VM customizations...
==> ansible-nodejs: Booting VM...
==> ansible-nodejs: Waiting for machine to boot. This may take a few minutes...
    ansible-nodejs: SSH address: 127.0.0.1:2222
    ansible-nodejs: SSH username: vagrant
    ansible-nodejs: SSH auth method: private key
    ansible-nodejs: 
    ansible-nodejs: Vagrant insecure key detected. Vagrant will automatically replace
    ansible-nodejs: this with a newly generated keypair for better security.
    ansible-nodejs: 
    ansible-nodejs: Inserting generated public key within guest...
    ansible-nodejs: Removing insecure key from the guest if it's present...
    ansible-nodejs: Key inserted! Disconnecting and reconnecting using new SSH key...
==> ansible-nodejs: Machine booted and ready!
==> ansible-nodejs: Checking for guest additions in VM...
    ansible-nodejs: No guest additions were detected on the base box for this VM! Guest
    ansible-nodejs: additions are required for forwarded ports, shared folders, host only
    ansible-nodejs: networking, and more. If SSH fails on this machine, please install
    ansible-nodejs: the guest additions and repackage the box to continue.
    ansible-nodejs: 
    ansible-nodejs: This is not an error message; everything may continue to work properly,
    ansible-nodejs: in which case you may ignore this message.
==> ansible-nodejs: Setting hostname...
==> ansible-nodejs: Rsyncing folder: /home/gtirloni/code/idrc/ansible-nodejs/ => /vagrant
==> ansible-nodejs: Machine not provisioned because `--no-provision` is specified.
--> Starting Ansible Run...

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [ansible-nodejs]

TASK [ansible-facts : Set Fedora related facts] ********************************
skipping: [ansible-nodejs]

TASK [ansible-facts : Set CentOS related facts] ********************************
ok: [ansible-nodejs]

TASK [ansible-facts : Determine if Atomic] *************************************
ok: [ansible-nodejs]

TASK [ansible-facts : Set Atomic related facts] ********************************
skipping: [ansible-nodejs]

TASK [ansible-facts : Determine if has RPM] ************************************
ok: [ansible-nodejs]

TASK [ansible-facts : Set RPM related facts] ***********************************
ok: [ansible-nodejs]

TASK [ansible-facts : Check for Docker related file] ***************************
ok: [ansible-nodejs]

TASK [ansible-facts : Set Docker fact to true] *********************************
skipping: [ansible-nodejs]

TASK [ansible-facts : Check for Vagrant related directory] *********************
ok: [ansible-nodejs]

TASK [ansible-facts : Set Vagrant fact to true] ********************************
ok: [ansible-nodejs]

TASK [ansible-nodejs : Include OS-specific variables] **************************
ok: [ansible-nodejs]

TASK [ansible-nodejs : Install Yum Utilities] **********************************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Enable Node.js LTS repository on Fedora] ****************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Enable Node.js Current repository on Fedora] ************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Install latest Node.js version on Fedora] ***************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Install specific Node.js version on Fedora] *************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Install additional RPM packages on Fedora] **************
[DEPRECATION WARNING]: Invoking "dnf" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: {{ item }}`, please use `name: [u'{{ nodejs_rpm_packages 
}}', u'{{ nodejs_app_rpm_packages }}']` and remove the loop. This feature will 
be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
skipping: [ansible-nodejs] => (item=[]) 

TASK [ansible-nodejs : Ensure rsync is installed for npm path workaround if a Fedora Vagrant environment is being used] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Enable Node.js LTS repository on CentOS] ****************
changed: [ansible-nodejs]

TASK [ansible-nodejs : Enable Node.js Current repository on CentOS] ************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Install latest Node.js version on CentOS] ***************
changed: [ansible-nodejs]

TASK [ansible-nodejs : Install specific Node.js version on CentOS] *************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Fail if nodejs- RPM packages are specified in nodejs_app_rpm_packages] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Install additional RPM packages on CentOS] **************
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: {{ item }}`, please use `name: [u'{{ nodejs_rpm_packages 
}}', u'{{ nodejs_app_rpm_packages }}']` and remove the loop. This feature will 
be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
changed: [ansible-nodejs] => (item=[u'git', u'gcc-c++'])

TASK [ansible-nodejs : Enable Yarn repository on CentOS/Fedora] ****************
changed: [ansible-nodejs]

TASK [ansible-nodejs : Install Yarn package manager on CentOS/Fedora] **********
changed: [ansible-nodejs]

TASK [ansible-nodejs : Ensure rsync is installed for npm path workaround if a CentOS Vagrant environment is being used] ***
ok: [ansible-nodejs]

TASK [ansible-nodejs : Adjust npm version] *************************************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Install required npm packages] **************************
changed: [ansible-nodejs] => (item=grunt-cli)
changed: [ansible-nodejs] => (item=testem)
changed: [ansible-nodejs] => (item=istanbul)

TASK [ansible-nodejs : Install nodemon if a development environment is being used] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Ensure the application group exists] ********************
changed: [ansible-nodejs]

TASK [ansible-nodejs : Ensure the application user account exists] *************
changed: [ansible-nodejs]

TASK [ansible-nodejs : Clone application repository] ***************************
>> Newly checked out 0bd06034e9fbef9803c054009121aaeea788c9fb
changed: [ansible-nodejs]

TASK [ansible-nodejs : Make sure the application install directory exists and is owned by the appropriate user] ***
ok: [ansible-nodejs]

TASK [ansible-nodejs : Run application related commands as the application user] ***

TASK [ansible-nodejs : Create systemd unit configuration] **********************
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Ensure systemd unit is enabled and restarted] ***********
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Create Supervisor config for Docker containers] *********
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Ensure Supervisord will start the application as a background process in a Docker container] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Start Supervisord and application in a Docker container] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Wait for the application to finish initializing before proceeding] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Test the application endpoint and check the result for the presence of a requested string] ***
skipping: [ansible-nodejs]

TASK [ansible-nodejs : Fail if requested string is not found] ******************
skipping: [ansible-nodejs]

PLAY RECAP *********************************************************************
ansible-nodejs             : ok=20   changed=9    unreachable=0    failed=0

--> Idempotence test in progress (can take a few minutes)...
--> Starting Ansible Run...
Idempotence test passed.
--> Executing ansible-lint...
--> Destroying instances...
==> ansible-nodejs: Forcing shutdown of VM...
==> ansible-nodejs: Destroying VM and associated drives...
```